### PR TITLE
refactor(ProductType): remove unused different_steps field

### DIFF
--- a/backend/src/main/java/gruppe2/backend/model/ProductTypeStep.java
+++ b/backend/src/main/java/gruppe2/backend/model/ProductTypeStep.java
@@ -1,0 +1,49 @@
+package gruppe2.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "product_type_steps")
+public class ProductTypeStep {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "product_type_id")
+    private ProductType productType;
+
+    @Column(name = "step_id")
+    private Long stepId;
+
+    @Column(name = "different_steps_order", nullable = false)
+    private Integer differentStepsOrder;
+
+    @Column(name = "step_order", nullable = false)
+    private Integer stepOrder;
+
+    public ProductTypeStep() {}
+
+    public ProductTypeStep(ProductType productType, Long stepId, Integer order) {
+        this.productType = productType;
+        this.stepId = stepId;
+        this.differentStepsOrder = order;
+        this.stepOrder = order;
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public ProductType getProductType() { return productType; }
+    public void setProductType(ProductType productType) { this.productType = productType; }
+
+    public Long getStepId() { return stepId; }
+    public void setStepId(Long stepId) { this.stepId = stepId; }
+
+    public Integer getDifferentStepsOrder() { return differentStepsOrder; }
+    public void setDifferentStepsOrder(Integer differentStepsOrder) { this.differentStepsOrder = differentStepsOrder; }
+
+    public Integer getStepOrder() { return stepOrder; }
+    public void setStepOrder(Integer stepOrder) { this.stepOrder = stepOrder; }
+}


### PR DESCRIPTION
- Remove unused different_steps field from ProductType entity
- Maintain backward compatibility through existing method names
- Improve code clarity by renaming parameters to be more descriptive
- Keep different_steps_order in ProductTypeStep for step ordering